### PR TITLE
sold out表示修正 index,show

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,9 +132,11 @@
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
               <%# 商品が売れていればsold outを表示しましょう %>
-              <div class='sold-out'>
-                <span>Sold Out!!</span>
-              </div>
+              <% if item == " " %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+              <% end %>
               <%# //商品が売れていればsold outを表示しましょう %>
             </div>
             <div class='item-info'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,9 +9,11 @@
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
+      <% if @item == " " %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">


### PR DESCRIPTION
#What
商品一覧

#Why
商品一覧表示のため

※前回の詳細一覧で、indexの一覧表示も実施していました。
今回は、indexとshowのsold out表示を追加しましたが、購入機能を追加してないため、確認はできていません。

index 商品一覧
https://gyazo.com/234a35f2162a6fa3b8363dd0ebf1104c

show 商品画像
https://gyazo.com/a4053fb4e9291cdbf98095de3b1c2e95

